### PR TITLE
[BREAKING] Rename truncation strategy to deletion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ The redis adapter only has one strategy: the deletion strategy.
 
 ## Strategy configuration options
 
-`:only` and `:except` may take a list of strings to be passed to [`keys`](https://redis.io/commands/keys)).
+`:only` and `:except` may take a list of strings to be passed to [`keys`](https://redis.io/commands/keys)):
+
+```ruby
+# Only delete the "users" key, and keys that start with "cache".
+DatabaseCleaner[:redis].strategy = :deletion, { only: ["users", "cache*"] }
+
+# Delete all keys except the "users" key.
+DatabaseCleaner[:redis].strategy = :deletion, { except: ["users"] }
+```
 
 ## Adapter configuration options
 

--- a/README.md
+++ b/README.md
@@ -19,41 +19,26 @@ end
 
 ## Supported Strategies
 
-<table>
-  <tbody>
-    <tr>
-      <th>Truncation</th>
-      <th>Transaction</th>
-      <th>Deletion</th>
-    </tr>
-    <tr>
-      <td> <b>Yes</b></td>
-      <td> No</td>
-      <td> No</td>
-    </tr>
-  </tbody>
-</table>
+The redis adapter only has one strategy: the deletion strategy.
 
-(Default strategy is denoted in bold)
+## Strategy configuration options
 
-## Configuration options
+`:only` and `:except` may take a list of strings to be passed to [`keys`](https://redis.io/commands/keys)).
 
-`:only` and `:except` take a list of strings to be passed to [`keys`](https://redis.io/commands/keys)).
+## Adapter configuration options
 
-<table>
-  <tbody>
-    <tr>
-      <th>ORM</th>
-      <th>How to access</th>
-      <th>Notes</th>
-    </tr>
-    <tr>
-      <td>Redis</td>
-      <td><code>DatabaseCleaner[:redis]</code></td>
-      <td>Connection specified as Redis URI</td>
-    </tr>
-  </tbody>
-</table>
+`#db` defaults to `Redis.new`, but can be specified manually in a few ways:
+
+```ruby
+# Redis URI string:
+DatabaseCleaner[:redis].db = "redis://localhost:6379/0"
+
+# Redis connection object:
+DatabaseCleaner[:redis].db = Redis.new(url: "redis://localhost:6379/0")
+
+# Back to default:
+DatabaseCleaner[:redis].db = :default
+```
 
 ## COPYRIGHT
 

--- a/lib/database_cleaner/redis.rb
+++ b/lib/database_cleaner/redis.rb
@@ -1,5 +1,5 @@
 require "database_cleaner/redis/version"
 require "database_cleaner/core"
-require "database_cleaner/redis/truncation"
+require "database_cleaner/redis/deletion"
 
-DatabaseCleaner[:redis].strategy = :truncation
+DatabaseCleaner[:redis].strategy = :deletion

--- a/lib/database_cleaner/redis/deletion.rb
+++ b/lib/database_cleaner/redis/deletion.rb
@@ -2,7 +2,7 @@ require "database_cleaner/strategy"
 
 module DatabaseCleaner
   module Redis
-    class Truncation < Strategy
+    class Deletion < Strategy
       def initialize only: [], except: []
         @only = only
         @except = except

--- a/spec/database_cleaner/redis/deletion_spec.rb
+++ b/spec/database_cleaner/redis/deletion_spec.rb
@@ -1,8 +1,8 @@
 require 'redis'
-require 'database_cleaner/redis/truncation'
+require 'database_cleaner/redis/deletion'
 require 'yaml'
 
-RSpec.describe DatabaseCleaner::Redis::Truncation do
+RSpec.describe DatabaseCleaner::Redis::Deletion do
   around do |example|
     config = YAML::load(File.open("spec/support/redis.yml"))
     @redis = ::Redis.new :url => config['test']['url']
@@ -18,7 +18,7 @@ RSpec.describe DatabaseCleaner::Redis::Truncation do
   end
 
   context "by default" do
-    it "truncates all keys" do
+    it "deletes all keys" do
       expect { subject.clean }.to change { @redis.keys.size }.from(2).to(0)
     end
   end
@@ -27,7 +27,7 @@ RSpec.describe DatabaseCleaner::Redis::Truncation do
     context "with concrete keys" do
       subject { described_class.new(only: ['Widget']) }
 
-      it "only truncates the specified keys" do
+      it "only deletes the specified keys" do
         expect { subject.clean }.to change { @redis.keys.size }.from(2).to(1)
         expect(@redis.get('Gadget')).to eq '1'
       end
@@ -36,7 +36,7 @@ RSpec.describe DatabaseCleaner::Redis::Truncation do
     context "with wildcard keys" do
       subject { described_class.new(only: ['Widge*']) }
 
-      it "only truncates the specified keys" do
+      it "only deletes the specified keys" do
         expect { subject.clean }.to change { @redis.keys.size }.from(2).to(1)
         expect(@redis.get('Gadget')).to eq '1'
       end
@@ -47,7 +47,7 @@ RSpec.describe DatabaseCleaner::Redis::Truncation do
     context "with concrete keys" do
       subject { described_class.new(except: ['Widget']) }
 
-      it "truncates all but the specified keys" do
+      it "deletes all but the specified keys" do
         expect { subject.clean }.to change { @redis.keys.size }.from(2).to(1)
         expect(@redis.get('Widget')).to eq '1'
       end
@@ -56,7 +56,7 @@ RSpec.describe DatabaseCleaner::Redis::Truncation do
     context "with wildcard keys" do
       subject { described_class.new(except: ['Widg*']) }
 
-      it "truncates all but the specified keys" do
+      it "deletes all but the specified keys" do
         expect { subject.clean }.to change { @redis.keys.size }.from(2).to(1)
         expect(@redis.get('Widget')).to eq '1'
       end


### PR DESCRIPTION
Redis doesn't have a truncate command, and the Redis command actually being invoked here on the database is named `del`, so I think this makes sense.

Will need to add deprecation warnings to 1.99 for this transition.

Also, I fixed up the configuration docs in the README while I was at it.