### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: 'Ruby: ${{ matrix.ruby }}'
+    runs-on: 'ubuntu-20.04'
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.1', '3.0', '2.7', '2.6', '2.5']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # 'bundle install' and cache
+      - name: Run tests
+        run: bundle exec rake
+
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-services:
-  - redis
-rvm:
-  - 2.5
-  - 2.6
-  - 2.7
-before_script:
-  - bin/setup


### PR DESCRIPTION
This PR introduces GitHub Actions to replace the now unsupported TravisCI.org

It also extends the list of Rubies tested in CI to include Ruby 3.0 and 3.1.